### PR TITLE
Add reproducible puzzle generation via seed parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ print(stats.solutions)  # -> 2
 
 This demonstrates how pieces are defined and used to cover a simple shape.
 
+## Command-line puzzle generation
+
+Running `python ubongo.py` will generate a sample puzzle using the built-in
+piece library.  You can supply a `--seed` argument to make puzzle generation
+reproducible:
+
+```bash
+python ubongo.py --seed 42
+```
+
+Using the same seed will always yield the same puzzle layout and statistics.
+
 ---
 
 This README is a draft and can be extended with more detailed usage examples and contributor guidelines.

--- a/tests/test_seed_reproducibility.py
+++ b/tests/test_seed_reproducibility.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ubongo import generate_puzzle_with_mandatory_alt, PIECES
+
+
+def test_puzzle_generation_is_seed_deterministic():
+    kwargs = dict(
+        library=PIECES,
+        k=3,
+        max_w=8,
+        max_h=6,
+        mandatory_piece="I3",
+        seed=123,
+        max_attempts=100,
+    )
+    p1 = generate_puzzle_with_mandatory_alt(**kwargs)
+    p2 = generate_puzzle_with_mandatory_alt(**kwargs)
+    assert p1 == p2


### PR DESCRIPTION
## Summary
- allow `solve_cover` to accept a custom RNG for deterministic behaviour
- expose `--seed` command line option and wire generator to use it
- document CLI puzzle generation and add test ensuring puzzles repeat for the same seed

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ae123fad448330af7c8e6eeb2e6a61