### PR TITLE
Add CLI parameter for puzzle piece count

### DIFF
--- a/ubongo.py
+++ b/ubongo.py
@@ -474,6 +474,12 @@ if __name__ == "__main__":
     parser.add_argument(
         "--seed", type=int, default=None, help="Seed for reproducible puzzle generation"
     )
+    parser.add_argument(
+        "--pieces",
+        type=int,
+        default=3,
+        help="Number of pieces to construct the puzzle with",
+    )
     args = parser.parse_args()
 
     # Example: Build a puzzle that has a constructive solution with k pieces
@@ -481,7 +487,7 @@ if __name__ == "__main__":
     # must include the mandatory piece "I3".
     puzzle = generate_puzzle_with_mandatory_alt(
         library=PIECES,
-        k=3,
+        k=args.pieces,
         max_w=8,
         max_h=6,
         mandatory_piece="I3",   # configurable at call-site


### PR DESCRIPTION
## Summary
- Allow configuring number of pieces via new `--pieces` CLI option
- Pass CLI-specified piece count to `generate_puzzle_with_mandatory_alt`

## Testing
- `python ubongo.py --help`
- `python ubongo.py --seed 123 --pieces 3`
- `python ubongo.py --seed 123 --pieces 4`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68afe7b1c4f08330b6b3d3155afbe9e1