### PR TITLE
Add circumference ratio histogram experiment script

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ python ubongo.py --seed 42
 
 Using the same seed will always yield the same puzzle layout and statistics.
 
+## Circumference ratio experiment
+
+The repository includes `experiment.py` which samples 100 random puzzles with
+different seeds and plots a histogram of their circumference-to-area ratios.
+Run:
+
+```bash
+python experiment.py
+```
+
+`matplotlib` is required to display the histogram.
+
 ---
 
 This README is a draft and can be extended with more detailed usage examples and contributor guidelines.

--- a/experiment.py
+++ b/experiment.py
@@ -1,0 +1,31 @@
+import matplotlib.pyplot as plt
+from ubongo import PIECES, generate_puzzle_with_mandatory_alt
+
+
+def main():
+    ratios = []
+    for seed in range(100):
+        puzzle = generate_puzzle_with_mandatory_alt(
+            library=PIECES,
+            k=3,
+            max_w=8,
+            max_h=6,
+            mandatory_piece="I3",
+            seed=seed,
+            max_attempts=600,
+        )
+        if puzzle is not None:
+            ratios.append(puzzle["circumference_ratio"])
+        else:
+            print(f"No puzzle found for seed {seed}; skipping.")
+
+    plt.hist(ratios, bins="auto", edgecolor="black")
+    plt.title("Circumference Ratio Distribution for 100 Ubongo Puzzles")
+    plt.xlabel("Circumference / Area ratio")
+    plt.ylabel("Frequency")
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+matplotlib>=3.8
 pytest>=6.0


### PR DESCRIPTION
## Summary
- add `experiment.py` to sample 100 Ubongo puzzles and plot circumference/area ratios
- document the experiment script in the README
- include matplotlib dependency for the experiment

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68afe812b3e48330ae8c523307dcdddb