### PR TITLE
Add translation-invariant puzzle hash and tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+hashlib
 matplotlib>=3.8
 pytest>=6.0

--- a/tests/test_puzzle_hash.py
+++ b/tests/test_puzzle_hash.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+# Ensure the project root is on the path for direct module imports
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from ubongo import puzzle_hash, parse_polyomino
+
+
+def test_ascii_and_cells_inputs_same_hash():
+    cells = parse_polyomino("square", "##\n##").base
+    ascii_art = "##\n##"
+    assert puzzle_hash(cells=cells) == puzzle_hash(ascii_art=ascii_art)
+
+
+def test_different_puzzles_different_hashes():
+    h_square = puzzle_hash(ascii_art="##\n##")
+    h_lshape = puzzle_hash(ascii_art="#.\n##")
+    assert h_square != h_lshape


### PR DESCRIPTION
## Summary
- add `puzzle_hash` utility that normalizes coordinates and hashes with BLAKE2b
- document translation-invariant puzzle hashing
- test hashing equality for ASCII and cell inputs and difference for distinct puzzles
- list `hashlib` in requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4978da8588330a36970934383ebf9