### PR TITLE
Add LaTeX puzzle sheet generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,21 @@ python experiment.py
 
 `matplotlib` is required to display the histogram.
 
+## Generating printable puzzle sheets
+
+`print_puzzles.py` converts a JSON list of puzzles (as produced by
+`experiment.py` or `ubongo.py`) into a LaTeX document ready for printing.  The
+generated drawings use a TikZ grid where each square measures exactly 12.5 mm,
+matching the physical pieces.
+
+Duplicate boards are filtered using `puzzle_hash` and every puzzle is annotated
+with the number of pieces and its hash value.  The script arranges up to four
+puzzles per A4 page.
+
+```bash
+python print_puzzles.py puzzles.json puzzles.tex
+```
+
 ---
 
 This README is a draft and can be extended with more detailed usage examples and contributor guidelines.

--- a/print_puzzles.py
+++ b/print_puzzles.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Generate a LaTeX document with Ubongo puzzles.
+
+This script reads a JSON file containing a list of puzzle dictionaries as
+produced by :func:`generate_puzzle_with_mandatory_alt` in ``ubongo.py`` and
+creates a LaTeX document ready for printing.  Each puzzle is drawn using TikZ
+with squares sized at 12.5mm so real pieces fit exactly on the printout.
+
+Duplicate puzzles (same layout) are removed using ``puzzle_hash``.  Every puzzle
+is annotated with the number of pieces in the constructive subset and its hash
+value for reference.
+
+Example usage:
+    python print_puzzles.py puzzles.json output.tex
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, List, Dict, Tuple
+
+from ubongo import puzzle_hash
+
+CELL_MM = 12.5  # millimetres per cell when rendered
+
+
+def ascii_to_tikz(ascii_art: str) -> str:
+    """Return a TikZ picture representing the ASCII shape."""
+    lines = [line.rstrip('\n') for line in ascii_art.splitlines() if line.strip('\n')]
+    if not lines:
+        return ""
+    h = len(lines)
+    w = max(len(line) for line in lines)
+    tikz = [f"\\begin{{tikzpicture}}[x={CELL_MM}mm,y={CELL_MM}mm]"]
+    for y, line in enumerate(lines):
+        for x, ch in enumerate(line):
+            if ch == '#':
+                yy = h - y - 1
+                tikz.append(
+                    f"\\draw[thick] ({x},{yy}) rectangle ({x+1},{yy+1});"
+                )
+    tikz.append("\\end{tikzpicture}")
+    return "\n".join(tikz)
+
+
+def unique_puzzles(puzzles: Iterable[Dict]) -> List[Tuple[int, Dict]]:
+    """Return a list of (hash, puzzle) for unique puzzles."""
+    seen = set()
+    uniq: List[Tuple[int, Dict]] = []
+    for p in puzzles:
+        h = puzzle_hash(ascii_art=p["ascii"])
+        if h in seen:
+            continue
+        seen.add(h)
+        uniq.append((h, p))
+    return uniq
+
+
+def puzzles_to_latex(puzzles: Iterable[Dict]) -> str:
+    """Convert puzzles to a LaTeX document string."""
+    entries: List[str] = []
+    for h, p in unique_puzzles(puzzles):
+        pieces = len(p.get("subset_S", []))
+        tikz = ascii_to_tikz(p["ascii"])
+        entry = (
+            "\\begin{minipage}{0.48\\textwidth}\\centering\n"
+            f"Pieces: {pieces} -- Hash: {h}\\\\[0.5ex]\n"
+            f"{tikz}\n"
+            "\\end{minipage}"
+        )
+        entries.append(entry)
+
+    doc: List[str] = [
+        "\\documentclass[a4paper]{article}",
+        "\\usepackage{tikz}",
+        "\\usepackage[margin=1cm]{geometry}",
+        "\\begin{document}",
+    ]
+
+    for i in range(0, len(entries), 4):
+        group = entries[i : i + 4]
+        doc.append("\\begin{center}\\begin{tabular}{cc}")
+        for r in range(2):
+            row_cells = []
+            for c in range(2):
+                idx = r * 2 + c
+                if idx < len(group):
+                    row_cells.append(group[idx])
+                else:
+                    row_cells.append("")
+            doc.append(" & ".join(row_cells) + " \\ ")
+        doc.append("\\end{tabular}\\end{center}")
+        if i + 4 < len(entries):
+            doc.append("\\newpage")
+
+    doc.append("\\end{document}")
+    return "\n".join(doc)
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Create printable puzzle sheets")
+    parser.add_argument("input", type=Path, help="JSON file with puzzle list")
+    parser.add_argument("output", type=Path, help="Output .tex file path")
+    args = parser.parse_args()
+
+    puzzles = json.loads(args.input.read_text())
+    tex = puzzles_to_latex(puzzles)
+    args.output.write_text(tex)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_latex_puzzles.py
+++ b/tests/test_latex_puzzles.py
@@ -1,0 +1,22 @@
+from print_puzzles import puzzles_to_latex
+from ubongo import puzzle_hash
+
+
+def test_dedup_and_annotations():
+    puzzles = [
+        {"ascii": "##\n##", "subset_S": ["A", "B", "C"]},
+        {"ascii": "##\n##", "subset_S": ["X"]},  # duplicate shape
+        {"ascii": "#.\n##", "subset_S": ["Y", "Z"]},
+    ]
+    tex = puzzles_to_latex(puzzles)
+
+    # Two unique puzzles -> two hashes
+    assert tex.count("Hash:") == 2
+
+    # Hash of square appears and pieces count taken from first occurrence
+    h_square = puzzle_hash(ascii_art="##\n##")
+    assert f"Hash: {h_square}" in tex
+    assert "Pieces: 3" in tex  # from first entry
+
+    # Ensure scaling is correct
+    assert "x=12.5mm" in tex


### PR DESCRIPTION
## Summary
- introduce `print_puzzles.py` to turn puzzle lists into LaTeX sheets for printing
- annotate each puzzle with piece count and stable `puzzle_hash`
- document usage and add regression test for hash-based deduplication

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49f4a17d083309b2932bea968eec6