### PR TITLE
Make puzzle_hash invariant to rotations and reflections

### DIFF
--- a/tests/test_puzzle_hash.py
+++ b/tests/test_puzzle_hash.py
@@ -17,3 +17,22 @@ def test_different_puzzles_different_hashes():
     h_square = puzzle_hash("##\n##")
     h_lshape = puzzle_hash("#.\n##")
     assert h_square != h_lshape
+
+
+def mirror_horizontal(ascii_art: str) -> str:
+    """Return the puzzle mirrored along the vertical axis."""
+    return "\n".join(line[::-1] for line in ascii_art.splitlines())
+
+
+def mirror_vertical(ascii_art: str) -> str:
+    """Return the puzzle mirrored along the horizontal axis."""
+    return "\n".join(reversed(ascii_art.splitlines()))
+
+
+def test_puzzle_hash_mirror_invariance():
+    puzzle = "#.....\n##....\n.###..\n...###"
+    ph = puzzle_hash(puzzle)
+    phh = puzzle_hash(mirror_horizontal(puzzle))
+    phv = puzzle_hash(mirror_vertical(puzzle))
+
+    assert ph == phh == phv

--- a/ubongo.py
+++ b/ubongo.py
@@ -155,10 +155,10 @@ def circumference_ratio(cells: FrozenSet[Cell]) -> float:
 def puzzle_hash(ascii_art: str) -> int:
     """Return a stable integer hash for the given puzzle shape.
 
-    The hash is computed from the normalized coordinates of all filled
-    cells parsed from ``ascii_art`` (``'#'`` denotes filled cells).  Equivalent
-    puzzles – i.e. shapes that are mere translations of each other –
-    therefore yield identical hashes.
+    The hash is computed from the canonical coordinates of all filled
+    cells parsed from ``ascii_art`` (``'#'`` denotes filled cells).
+    Shapes that are mere translations, rotations or reflections of each
+    other therefore yield identical hashes.
     """
 
     lines = dedent(ascii_art).splitlines()
@@ -169,7 +169,9 @@ def puzzle_hash(ascii_art: str) -> int:
                 cells.add((x, y))
 
     normalized = normalize(frozenset(cells))
-    serial = ','.join(f"{x}:{y}" for x, y in sorted(normalized))
+    variants = dihedral_orientations(normalized)
+    canonical = min(tuple(sorted(v)) for v in variants)
+    serial = ','.join(f"{x}:{y}" for x, y in canonical)
     digest = hashlib.blake2b(serial.encode('utf-8'), digest_size=16).digest()
     return int.from_bytes(digest, 'big')
 


### PR DESCRIPTION
## Summary
- canonicalize puzzle_hash by scanning all dihedral orientations and hashing the minimal coordinate set
- document and test hash invariance for mirrored puzzles

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4b66543e88330b638453a7a6da47c